### PR TITLE
Update base container and freeze requirements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/default-test-container:2.5.0
+FROM quay.io/ansible/default-test-container:2.6.0
 
 COPY files/requirements.sh /tmp/requirements-base.sh
 COPY requirements/*.txt /tmp/requirements-base/

--- a/freeze/3.6.txt
+++ b/freeze/3.6.txt
@@ -98,7 +98,7 @@ oslo.config==8.1.0
 oslo.context==3.1.0
 oslo.i18n==5.0.0
 oslo.log==4.2.1
-oslo.serialization==3.2.0
+oslo.serialization==4.0.0
 oslo.utils==4.2.1
 packaging==20.4
 paramiko==2.7.1


### PR DESCRIPTION
This change brings in Python 3.8.0b3 and other updates from the base container.